### PR TITLE
fix: clean up artifact cache

### DIFF
--- a/components/rootless_studio/Dockerfile
+++ b/components/rootless_studio/Dockerfile
@@ -4,4 +4,5 @@ ARG BIO_VERSION=
 ARG PACKAGE_TARGET
 RUN set -ex \
     && apk add --no-cache ca-certificates curl bash \
-    && curl https://raw.githubusercontent.com/biome-sh/biome/master/components/bio/install-linux.sh | bash
+    && curl https://raw.githubusercontent.com/biome-sh/biome/master/components/bio/install-linux.sh | bash \
+    && rm /hab/cache/artifacts/*.hart


### PR DESCRIPTION
I noticed that the `biomesh/bio-x86_64-linux` docker image has an extra 5.9MB in it that don't need to be there in `/hab/cache/artifacts/biome-bio-1.6.821-20230811153141-x86_64-linux.hart`